### PR TITLE
feat: 在注册成功和修改密码提示中添加用户的Telegram账号ID信息

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -531,7 +531,7 @@ async function handleStartCommand(bot_token, userId, chatId, chatType, GROUP_ID,
 
             if (registrationSuccess) {
                 // 注册成功
-                responseMessage = `✅ 注册成功！\n\n🌐 服务器地址：<code>${moontvUrl}</code>\n🆔 用户名：<code>${userId}</code>\n🔑 访问密码：<code>${initialPassword}</code>\n\n💡 使用 <code>/pwd 新密码</code> 可以修改密码\n\n⚠️ 请妥善保存密码，忘记密码可通过修改密码命令重置`;
+                responseMessage = `✅ 注册成功！\n\n🌐 服务器地址：<code>${moontvUrl}</code>\n🆔 用户名：<code>${userId}</code> (您的Telegram账号ID)\n🔑 访问密码：<code>${initialPassword}</code>\n\n💡 使用 <code>/pwd 新密码</code> 可以修改密码\n\n⚠️ 请妥善保存密码，忘记密码可通过修改密码命令重置`;
             } else {
                 // 3次尝试后仍然失败
                 console.error(`经过${maxRetries}次尝试后注册仍然失败，最后错误:`, lastError);
@@ -540,7 +540,7 @@ async function handleStartCommand(bot_token, userId, chatId, chatType, GROUP_ID,
             }
         } else {
             // 用户已存在，显示当前信息
-            responseMessage = `ℹ️ 你已注册过账户\n\n🌐 服务器地址：<code>${moontvUrl}</code>\n🆔 用户名：<code>${userId}</code>\n\n💡 使用 <code>/pwd 新密码</code> 可以修改密码\n\n⚠️ 如忘记密码，可直接通过修改密码命令重置`;
+            responseMessage = `ℹ️ 你已注册过账户\n\n🌐 服务器地址：<code>${moontvUrl}</code>\n🆔 用户名：<code>${userId}</code> (您的Telegram账号ID)\n\n💡 使用 <code>/pwd 新密码</code> 可以修改密码\n\n⚠️ 如忘记密码，可直接通过修改密码命令重置`;
         }
 
         await sendMessage(bot_token, chatId, responseMessage, moontvUrl, actualSiteName, appInfo);
@@ -737,7 +737,7 @@ async function handlePasswordCommand(bot_token, userId, chatId, chatType, GROUP_
                 throw new Error('修改密码失败');
             }
 
-            await sendMessage(bot_token, chatId, `✅ 密码修改成功！\n\n🆔 用户名：<code>${userId}</code>\n🔑 新密码：<code>${newPassword}</code>\n\n💡 新密码已生效，请妥善保存`, moontvUrl);
+            await sendMessage(bot_token, chatId, `✅ 密码修改成功！\n\n🆔 用户名：<code>${userId}</code> (您的Telegram账号ID)\n🔑 新密码：<code>${newPassword}</code>\n\n💡 新密码已生效，请妥善保存`, moontvUrl);
             return new Response('OK');
         } catch (apiError) {
             console.error('修改密码API失败:', apiError);


### PR DESCRIPTION
This pull request updates user-facing messages in the `_worker.js` file to clarify that the displayed username corresponds to the user's Telegram account ID. This change improves transparency for users interacting with registration and password-related commands.

User message improvements:

* Updated registration success message to indicate that `userId` is the user's Telegram account ID, helping users understand what their account identifier represents.
* Updated "already registered" account information message to clarify that the username shown is the Telegram account ID.
* Updated password change success message to explicitly state that the username is the Telegram account ID.