### PR TITLE
Beta

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -855,7 +855,7 @@ async function sendMessage(bot_token, chatId, text, moontvUrl = null, siteName =
 
         // 如果提供了 moontvUrl，添加观影站点按钮
         if (moontvUrl && siteName) {
-            const buttonText = `🎬 ${siteName}观影站点`;
+            const buttonText = `🎬 ${siteName}在线观影`;
             inlineKeyboard.push([{
                 text: buttonText,
                 url: moontvUrl
@@ -868,6 +868,13 @@ async function sendMessage(bot_token, chatId, text, moontvUrl = null, siteName =
             inlineKeyboard.push([{
                 text: appButtonText,
                 url: appInfo.downloadUrl
+            }]);
+        } else {
+            // 添加默认的APP下载按钮
+            const defaultAppButtonText = '📱 APP客户端下载';
+            inlineKeyboard.push([{
+                text: defaultAppButtonText,
+                url: 'https://github.com/MoonTechLab/Selene/releases'
             }]);
         }
 

--- a/_worker.js
+++ b/_worker.js
@@ -531,7 +531,7 @@ async function handleStartCommand(bot_token, userId, chatId, chatType, GROUP_ID,
 
             if (registrationSuccess) {
                 // 注册成功
-                responseMessage = `✅ 注册成功！\n\n🌐 <b>服务器：</b><code>${moontvUrl}</code>\n🆔 <b>用户名：</b><code>${userId}</code> (您的Telegram数字ID)\n🔑 <b>访问密码：</b><code>${initialPassword}</code>\n\n💡 使用 <code>/pwd 新密码</code> 可以修改密码\n\n⚠️ 请妥善保存密码，忘记密码可通过修改密码命令重置`;
+                responseMessage = `✅ 注册成功！\n\n🌐 <b>服务器：</b><code>${moontvUrl}</code>\n🆔 <b>用户名：</b><code>${userId}</code> (您的TG数字ID)\n🔑 <b>访问密码：</b><code>${initialPassword}</code>\n\n💡 使用 <code>/pwd 新密码</code> 可以修改密码\n\n⚠️ 请妥善保存密码，忘记密码可通过修改密码命令重置`;
             } else {
                 // 3次尝试后仍然失败
                 console.error(`经过${maxRetries}次尝试后注册仍然失败，最后错误:`, lastError);
@@ -540,7 +540,7 @@ async function handleStartCommand(bot_token, userId, chatId, chatType, GROUP_ID,
             }
         } else {
             // 用户已存在，显示当前信息
-            responseMessage = `ℹ️ 你已注册过账户\n\n🌐 <b>服务器：</b><code>${moontvUrl}</code>\n🆔 <b>用户名：</b><code>${userId}</code> (您的Telegram数字ID)\n\n💡 使用 <code>/pwd 新密码</code> 可以修改密码\n\n⚠️ 如忘记密码，可直接通过修改密码命令重置`;
+            responseMessage = `ℹ️ 你已注册过账户\n\n🌐 <b>服务器：</b><code>${moontvUrl}</code>\n🆔 <b>用户名：</b><code>${userId}</code> (您的TG数字ID)\n\n💡 使用 <code>/pwd 新密码</code> 可以修改密码\n\n⚠️ 如忘记密码，可直接通过修改密码命令重置`;
         }
 
         await sendMessage(bot_token, chatId, responseMessage, moontvUrl, actualSiteName, appInfo);
@@ -737,7 +737,7 @@ async function handlePasswordCommand(bot_token, userId, chatId, chatType, GROUP_
                 throw new Error('修改密码失败');
             }
 
-            await sendMessage(bot_token, chatId, `✅ 密码修改成功！\n\n🆔 <b>用户名：</b><code>${userId}</code> (您的Telegram数字ID)\n🔑 <b>访问密码：</b><code>${newPassword}</code>\n\n💡 新密码已生效，请妥善保存`, moontvUrl);
+            await sendMessage(bot_token, chatId, `✅ 密码修改成功！\n\n🆔 <b>用户名：</b><code>${userId}</code> (您的TG数字ID)\n🔑 <b>访问密码：</b><code>${newPassword}</code>\n\n💡 新密码已生效，请妥善保存`, moontvUrl);
             return new Response('OK');
         } catch (apiError) {
             console.error('修改密码API失败:', apiError);


### PR DESCRIPTION
This pull request makes several small but user-facing improvements to the messaging and button text in the `_worker.js` Telegram bot logic. The changes focus on clarifying terminology for users and enhancing the user interface by providing a default app download button.

**User messaging updates:**

* Changed the account information text from "Telegram数字ID" to "TG数字ID" for consistency and brevity in registration, account info, and password change messages. [[1]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL534-R534) [[2]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL543-R543) [[3]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL740-R740)

**User interface improvements:**

* Updated the site button text from "观影站点" to "在线观影" for clarity and improved user experience.
* Added a default "APP客户端下载" button linking to the GitHub releases page when specific app info is not provided, ensuring users always have access to the app download link.